### PR TITLE
Allow Spacelift to assume infrastructure roles

### DIFF
--- a/backend.yml
+++ b/backend.yml
@@ -33,6 +33,13 @@ Resources:
             Principal:
               AWS: !Sub "arn:aws:iam::${AWS::AccountId}:role/ops-admin"
             Action: sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              AWS: "324880187172"
+            Action: sts:AssumeRole
+            Condition:
+              StringLike:
+                sts:ExternalId: "jreslock@*"
       Policies:
         - PolicyName: StateManagementPolicy
           PolicyDocument:
@@ -64,5 +71,12 @@ Resources:
             Principal:
               AWS: !Sub "arn:aws:iam::${AWS::AccountId}:role/ops-admin"
             Action: sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              AWS: "324880187172"
+            Action: sts:AssumeRole
+            Condition:
+              StringLike:
+                sts:ExternalId: "jreslock@*"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AdministratorAccess


### PR DESCRIPTION
Spacelift can assume my infrastructure-operator and infrastructure-state-manager roles. I likely will not use the bucket or DDB table for state management but they will remain in place in case they are needed for other projects in the future.